### PR TITLE
Use ensure_packages

### DIFF
--- a/manifests/pyvenv.pp
+++ b/manifests/pyvenv.pp
@@ -47,9 +47,9 @@ define python::pyvenv (
       case $facts['lsbdistcodename'] {
         'xenial','bionic','cosmic','disco',
         'jessie','stretch','buster': {
-          package {$python3_venv_package:
+          ensure_packages ($python3_venv_package, {
             before => File[$venv_dir],
-          }
+          })
         }
           default: {}
       }


### PR DESCRIPTION
I get duplicate declaration error while creating two or more venvs - `ensure_packages` works around that.
